### PR TITLE
test: add CLI tests for new asset workflow

### DIFF
--- a/docs/NEW_ASSET_WORKFLOW_NOTES.md
+++ b/docs/NEW_ASSET_WORKFLOW_NOTES.md
@@ -1,0 +1,22 @@
+# New Asset Workflow Notes
+
+## Atlassian Assets Cloud API Endpoints
+- Creating an asset uses `POST /jsm/assets/workspace/{workspaceId}/v1/object/create`.
+- Model names can be fetched from `GET /jsm/assets/workspace/{workspaceId}/v1/objecttype/{objectTypeId}/objects`.
+- Available statuses are retrieved via `GET /jsm/assets/workspace/{workspaceId}/v1/objecttype/{objectTypeId}/attributes`.
+
+These endpoints were derived from Atlassian Assets Cloud API documentation. Attempts to access the documentation directly via curl returned HTTP 403 in this environment, so manual verification may be required.
+
+## Interactive CLI Flow
+1. Prompt user for asset serial number.
+2. Fetch available model names via `list_models` (uses *GET objecttype/objects*).
+3. Fetch available statuses via `list_statuses` (uses *GET objecttype/attributes*).
+4. Ask whether the asset is for a remote user (`y`/`n`).
+5. Submit details to `AssetManager.create_asset` which calls the *POST object/create* endpoint.
+6. Offer to add another asset; repeat from step 1 if the user answers `y`.
+
+## Dependency Versions
+- `requests` is pinned at `>=2.31.0` while the latest release is `2.32.5`.
+- `pytest` is installed at `8.4.1`; the latest release is `8.4.2`.
+
+Update the dependencies if newer releases contain security or compatibility fixes.

--- a/tests/test_new_asset_cli.py
+++ b/tests/test_new_asset_cli.py
@@ -1,0 +1,54 @@
+"""Tests for the forthcoming `--new` interactive asset workflow."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from src.main import main as cli_main
+from src.main import setup_argument_parser
+
+
+def test_parser_includes_new_option() -> None:
+    """Parser should recognize the `--new` flag."""
+
+    parser = setup_argument_parser()
+    args = parser.parse_args(["--new"])
+    assert getattr(args, "new", False) is True
+
+
+@pytest.mark.parametrize(
+    "serial,model,status,remote_input,expected_remote",
+    [
+        ("SN123", "Laptop Model A", "In Use", "y", True),
+        ("SN124", "Laptop Model B", "Storage", "n", False),
+    ],
+)
+def test_cli_new_adds_single_asset(monkeypatch, serial, model, status, remote_input, expected_remote) -> None:
+    """Interactive flow should create a single asset from user input."""
+
+    mock_manager = MagicMock()
+    mock_manager.list_models.return_value = ["Laptop Model A", "Laptop Model B"]
+    mock_manager.list_statuses.return_value = ["In Use", "Storage"]
+
+    monkeypatch.setattr("src.main.AssetManager", lambda: mock_manager)
+
+    user_inputs = iter([serial, model, status, remote_input, "n"])
+    monkeypatch.setattr("builtins.input", lambda *args: next(user_inputs))
+
+    monkeypatch.setattr(sys, "argv", ["main.py", "--new"])
+    exit_code = cli_main()
+
+    mock_manager.list_models.assert_called_once()
+    mock_manager.list_statuses.assert_called_once()
+    mock_manager.create_asset.assert_called_once_with(
+        serial=serial,
+        model_name=model,
+        status=status,
+        is_remote=expected_remote,
+    )
+    assert exit_code == 0


### PR DESCRIPTION
## Summary
- parameterize interactive `--new` workflow tests and assert asset creation with remote/non-remote paths
- document step-by-step interactive flow for adding assets

## Testing
- `ruff check tests/test_new_asset_cli.py`
- `black tests/test_new_asset_cli.py`
- `pytest -q tests/test_new_asset_cli.py` *(fails: one of the arguments --test-asset --bulk --retire-assets --oauth-setup --csv-migrate is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c681a267e883308883903c2cb55db8